### PR TITLE
Improved resolution of ambiguous attribute types

### DIFF
--- a/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/field/QueryInfoJPAAttributeNameBuilderTest.java
+++ b/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/field/QueryInfoJPAAttributeNameBuilderTest.java
@@ -29,13 +29,14 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.evanzeimet.queryinfo.jpa.attribute.QueryInfoAttributeType;
 import com.evanzeimet.queryinfo.jpa.test.entity.TestEmployeeEntity_;
 import com.evanzeimet.queryinfo.jpa.test.entity.TestOrganizationEntity;
 import com.evanzeimet.queryinfo.jpa.test.entity.TestOrganizationEntity_;
 import com.evanzeimet.queryinfo.jpa.test.entity.TestPersonEntity_;
 import com.evanzeimet.queryinfo.jpa.test.entity.TestQueryInfoEntityContextRegistry;
 
-public class QueryInfoJPAAtributeNameBuilderTest {
+public class QueryInfoJPAAttributeNameBuilderTest {
 
 	@Test
 	public void buildList_entityContextRegistry() {
@@ -96,6 +97,61 @@ public class QueryInfoJPAAtributeNameBuilderTest {
 				.add(TestPersonEntity_.firstName)
 				.buildString();
 		String expected = "employees.spouse.firstName";
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void buildString_leafAttributeType_field() {
+		TestQueryInfoEntityContextRegistry entityContextRegistry = TestQueryInfoEntityContextRegistry.create();
+
+		String actual = QueryInfoJPAAttributeNameBuilder.create(entityContextRegistry)
+				.root(TestOrganizationEntity.class)
+				.add(TestOrganizationEntity_.employeeEntities)
+				.add(TestEmployeeEntity_.spouse)
+				.buildString(QueryInfoAttributeType.FIELD);
+		String expected = "employees.spouseEntity";
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void buildString_leafAttributeType_join() {
+		TestQueryInfoEntityContextRegistry entityContextRegistry = TestQueryInfoEntityContextRegistry.create();
+
+		String actual = QueryInfoJPAAttributeNameBuilder.create(entityContextRegistry)
+				.root(TestOrganizationEntity.class)
+				.add(TestOrganizationEntity_.employeeEntities)
+				.add(TestEmployeeEntity_.spouse)
+				.buildString(QueryInfoAttributeType.JOIN);
+		String expected = "employees.spouse";
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void buildString_leafAttributeType_unspecified_preferField() {
+		TestQueryInfoEntityContextRegistry entityContextRegistry = TestQueryInfoEntityContextRegistry.create();
+
+		String actual = QueryInfoJPAAttributeNameBuilder.create(entityContextRegistry)
+				.root(TestOrganizationEntity.class)
+				.add(TestOrganizationEntity_.employeeEntities)
+				.add(TestEmployeeEntity_.spouse)
+				.buildString();
+		String expected = "employees.spouseEntity";
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void buildString_leafAttributeType_unspecified_fallbackToJoin() {
+		TestQueryInfoEntityContextRegistry entityContextRegistry = TestQueryInfoEntityContextRegistry.create();
+
+		String actual = QueryInfoJPAAttributeNameBuilder.create(entityContextRegistry)
+				.root(TestOrganizationEntity.class)
+				.add(TestOrganizationEntity_.employeeEntities)
+				.buildString();
+		String expected = "employees";
 
 		assertEquals(expected, actual);
 	}

--- a/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/test/entity/TestPersonEntity.java
+++ b/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/test/entity/TestPersonEntity.java
@@ -72,6 +72,7 @@ public class TestPersonEntity extends TestAbstractMappedSuperclass {
 	}
 
 	@QueryInfoJoin
+	@QueryInfoField(name = "spouseEntity")
 	@OneToOne
 	public TestPersonEntity getSpouse() {
 		return spouse;


### PR DESCRIPTION
Attributes can be field/join/both.  Use explicit, or prefer field but find either.