### PR TITLE
Add QueryInfoUtils::createSelectionsForAttributePaths

### DIFF
--- a/common/src/main/java/com/evanzeimet/queryinfo/QueryInfoUtils.java
+++ b/common/src/main/java/com/evanzeimet/queryinfo/QueryInfoUtils.java
@@ -35,6 +35,7 @@ import com.evanzeimet.queryinfo.condition.DefaultConditionGroup;
 import com.evanzeimet.queryinfo.pagination.DefaultPaginationInfo;
 import com.evanzeimet.queryinfo.pagination.PaginationInfo;
 import com.evanzeimet.queryinfo.selection.Selection;
+import com.evanzeimet.queryinfo.selection.SelectionBuilder;
 import com.evanzeimet.queryinfo.sort.Sort;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JavaType;
@@ -225,6 +226,20 @@ public class QueryInfoUtils {
 		result.setDateFormat(dateFormat);
 
 		result.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+		return result;
+	}
+
+	public List<Selection> createSelectionsForAttributePaths(List<String> attributePaths) {
+		int attributePathCount = attributePaths.size();
+		List<Selection> result = new ArrayList<>(attributePathCount);
+		SelectionBuilder selectionBuilder = SelectionBuilder.create();
+
+		for (String attributePath : attributePaths) {
+			Selection selection = selectionBuilder.attributePath(attributePath)
+					.build();
+			result.add(selection);
+		}
 
 		return result;
 	}

--- a/common/src/test/java/com/evanzeimet/queryinfo/QueryInfoBuilderTest.java
+++ b/common/src/test/java/com/evanzeimet/queryinfo/QueryInfoBuilderTest.java
@@ -22,8 +22,16 @@ package com.evanzeimet.queryinfo;
  * #L%
  */
 
-import com.evanzeimet.queryinfo.QueryInfo;
-import com.evanzeimet.queryinfo.QueryInfoBuilder;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import com.evanzeimet.queryinfo.condition.Condition;
 import com.evanzeimet.queryinfo.condition.ConditionBuilder;
 import com.evanzeimet.queryinfo.condition.ConditionGroup;
@@ -39,16 +47,6 @@ import com.evanzeimet.queryinfo.sort.Sort;
 import com.evanzeimet.queryinfo.sort.SortBuilder;
 import com.evanzeimet.queryinfo.sort.SortDirection;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.*;
-
 public class QueryInfoBuilderTest {
 
 	private QueryInfoBuilder builder;
@@ -60,7 +58,8 @@ public class QueryInfoBuilderTest {
 
 	@Test
 	public void build()
-			throws IOException {
+			throws IOException,
+			QueryInfoException {
 		Condition givenNestedConditionGroupCondition1 = ConditionBuilder.create()
 				.leftHandSide("category")
 				.operator(ConditionOperator.EQUAL_TO)

--- a/common/src/test/java/com/evanzeimet/queryinfo/QueryInfoTestUtils.java
+++ b/common/src/test/java/com/evanzeimet/queryinfo/QueryInfoTestUtils.java
@@ -69,8 +69,16 @@ public class QueryInfoTestUtils {
 	}
 
 	public static String getFormattedJson(Class<?> clazz, String filename)
-			throws IOException {
+			throws IOException,
+			QueryInfoException {
 		URL url = clazz.getResource(filename);
+
+		if (url == null) {
+			String message = String.format("Resource not found at [%s]",
+					filename);
+			throw new QueryInfoException(message);
+		}
+
 		File file = new File(url.getPath());
 		String rawContents = FileUtils.readFileToString(file);
 

--- a/common/src/test/java/com/evanzeimet/queryinfo/QueryInfoUtilsTest.java
+++ b/common/src/test/java/com/evanzeimet/queryinfo/QueryInfoUtilsTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,8 +38,12 @@ import org.junit.Test;
 
 import com.evanzeimet.queryinfo.selection.Selection;
 import com.evanzeimet.queryinfo.selection.SelectionBuilder;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 public class QueryInfoUtilsTest {
+
+	protected static Type STRING_LIST_TYPE = new TypeReference<ArrayList<String>>() {
+	}.getType();
 
 	private QueryInfoUtils utils;
 	private final Integer defaultPageSize = 42;
@@ -90,6 +95,25 @@ public class QueryInfoUtilsTest {
 				"QueryInfoUtilsTest_coalesceQueryInfo_populated_expected.json");
 
 		assertEquals(expectedJson, actualJson);
+	}
+
+	@Test
+	public void createSelectionsForAttributePaths() throws IOException,
+			QueryInfoException {
+		String givenJson = QueryInfoTestUtils.getFormattedJson(getClass(),
+				"QueryInfoUtilsTest_createSelectionsForAttributePaths_given.json");
+
+		List<String> givenAttributePaths = QueryInfoTestUtils.objectify(givenJson,
+				STRING_LIST_TYPE);
+
+		List<Selection> actualSelections = utils.createSelectionsForAttributePaths(givenAttributePaths);
+
+		String actualJson = QueryInfoTestUtils.createActualJson(actualSelections);
+		String expectedJson = QueryInfoTestUtils.getFormattedJson(getClass(),
+				"QueryInfoUtilsTest_createSelectionsForAttributePaths_expected.json");
+
+		assertEquals(expectedJson,
+				actualJson);
 	}
 
 	@Test

--- a/common/src/test/java/com/evanzeimet/queryinfo/condition/ConditionGroupBuilderTest.java
+++ b/common/src/test/java/com/evanzeimet/queryinfo/condition/ConditionGroupBuilderTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.evanzeimet.queryinfo.QueryInfoException;
 import com.evanzeimet.queryinfo.QueryInfoTestUtils;
 
 public class ConditionGroupBuilderTest {
@@ -43,7 +44,8 @@ public class ConditionGroupBuilderTest {
 	}
 
 	@Test
-	public void build() throws IOException {
+	public void build() throws IOException,
+			QueryInfoException {
 		List<ConditionGroup> givenConditionGroups = new ArrayList<ConditionGroup>();
 
 		Condition givenCondition1 = ConditionBuilder.create()
@@ -80,7 +82,8 @@ public class ConditionGroupBuilderTest {
 	}
 
 	@Test
-	public void createForCondition() throws IOException {
+	public void createForCondition() throws IOException,
+			QueryInfoException {
 		Condition givenCondition = ConditionBuilder.create()
 				.leftHandSide("lhs1")
 				.operator("op1")
@@ -98,7 +101,8 @@ public class ConditionGroupBuilderTest {
 	}
 
 	@Test
-	public void createForConditionGroup() throws IOException {
+	public void createForConditionGroup() throws IOException,
+			QueryInfoException {
 		List<Condition> givenConditions = new ArrayList<Condition>();
 
 		Condition givenCondition = ConditionBuilder.create()

--- a/common/src/test/resources/com/evanzeimet/queryinfo/QueryInfoUtilsTest_createSelectionsForAttributePaths_expected.json
+++ b/common/src/test/resources/com/evanzeimet/queryinfo/QueryInfoUtilsTest_createSelectionsForAttributePaths_expected.json
@@ -1,0 +1,14 @@
+[
+  {
+    "attributePath" : "attributePath1"
+  },
+  {
+    "attributePath" : "attributePath2"
+  },
+  {
+    "attributePath" : "attributePath3"
+  },
+  {
+    "attributePath" : "attributePath4"
+  }
+]

--- a/common/src/test/resources/com/evanzeimet/queryinfo/QueryInfoUtilsTest_createSelectionsForAttributePaths_given.json
+++ b/common/src/test/resources/com/evanzeimet/queryinfo/QueryInfoUtilsTest_createSelectionsForAttributePaths_given.json
@@ -1,0 +1,6 @@
+[
+    "attributePath1",
+    "attributePath2",
+    "attributePath3",
+    "attributePath4"
+]

--- a/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/iterator/AllPaginatedResultsIteratorTest.java
+++ b/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/iterator/AllPaginatedResultsIteratorTest.java
@@ -11,9 +11,9 @@ package com.evanzeimet.queryinfo.jpa.iterator;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/result/TupleToObjectNodeQueryInfoResultConverterTest.java
+++ b/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/result/TupleToObjectNodeQueryInfoResultConverterTest.java
@@ -36,6 +36,7 @@ import javax.persistence.TupleElement;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.evanzeimet.queryinfo.QueryInfoException;
 import com.evanzeimet.queryinfo.QueryInfoTestUtils;
 import com.evanzeimet.queryinfo.QueryInfoUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,7 +56,8 @@ public class TupleToObjectNodeQueryInfoResultConverterTest {
 	}
 
 	@Test
-	public void convertTuple_nestedPojo() throws IOException {
+	public void convertTuple_nestedPojo() throws IOException,
+			QueryInfoException {
 		Tuple tuple = mock(Tuple.class);
 
 		List<TupleElement<?>> tupleElements = new ArrayList<>();


### PR DESCRIPTION
Add QueryInfoUtils::createSelectionsForAttributePaths, useful for creating selections
from group by attribute paths