### PR TITLE
Refactor Subquery Root Class Resolution

### DIFF
--- a/integration-tests-pu/src/main/java/com/evanzeimet/queryinfo/it/organizations/OrganizationEntity.java
+++ b/integration-tests-pu/src/main/java/com/evanzeimet/queryinfo/it/organizations/OrganizationEntity.java
@@ -88,7 +88,8 @@ public class OrganizationEntity extends DefaultOrganization {
 
 	@JsonIgnore
 	@QueryInfoJoin(name = "employees",
-			joinType = QueryInfoJoinType.LEFT)
+			joinType = QueryInfoJoinType.LEFT,
+			entityClass = PersonEntity.class)
 	@OneToMany(mappedBy = "employerEntity")
 	public List<PersonEntity> getEmployeeEntities() {
 		return employeeEntities;

--- a/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/attribute/QueryInfoAttributeInfo.java
+++ b/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/attribute/QueryInfoAttributeInfo.java
@@ -28,13 +28,17 @@ public interface QueryInfoAttributeInfo {
 
 	QueryInfoAttributeType getAttributeType();
 
-	String getJpaAttributeName();
+	Class<?> getEntityClass();
 
-	void setJpaAttributeName(String jpaAttributeName);
+	void setEntityClass(Class<?> entityClass);
 
 	QueryInfoJoinType getJoinType();
 
 	void setJoinType(QueryInfoJoinType joinType);
+
+	String getJpaAttributeName();
+
+	void setJpaAttributeName(String jpaAttributeName);
 
 	String getName();
 

--- a/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/attribute/QueryInfoAttributePurpose.java
+++ b/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/attribute/QueryInfoAttributePurpose.java
@@ -27,7 +27,6 @@ public enum QueryInfoAttributePurpose {
 	GROUP_BY,
 	ORDER,
 	PREDICATE,
-	SELECT,
-	SUBQUERY_ROOT;
+	SELECT;
 
 }

--- a/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/field/DefaultQueryInfoFieldInfo.java
+++ b/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/field/DefaultQueryInfoFieldInfo.java
@@ -27,6 +27,7 @@ import com.evanzeimet.queryinfo.jpa.join.QueryInfoJoinType;
 
 public class DefaultQueryInfoFieldInfo implements QueryInfoFieldInfo {
 
+	private Class<?> entityClass;
 	private String jpaAttributeName;
 	private Boolean isOrderable;
 	private Boolean isPredicateable;
@@ -41,6 +42,16 @@ public class DefaultQueryInfoFieldInfo implements QueryInfoFieldInfo {
 	@Override
 	public QueryInfoAttributeType getAttributeType() {
 		return QueryInfoAttributeType.FIELD;
+	}
+
+	@Override
+	public Class<?> getEntityClass() {
+		return entityClass;
+	}
+
+	@Override
+	public void setEntityClass(Class<?> entityClass) {
+		this.entityClass = entityClass;
 	}
 
 	@Override

--- a/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/field/QueryInfoField.java
+++ b/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/field/QueryInfoField.java
@@ -34,6 +34,12 @@ import com.evanzeimet.queryinfo.jpa.join.QueryInfoJoinType;
 @Target(METHOD)
 public @interface QueryInfoField {
 
+	/**
+	 * This is used in specific use-cases when you have a joined entity whose
+	 * class cannot be easily determined at run-time.
+	 */
+	public Class<?> entityClass() default QueryInfoField.class;
+
 	public boolean isOrderable() default true;
 
 	public boolean isPredicateable() default true;

--- a/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/field/QueryInfoFieldInfoBuilder.java
+++ b/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/field/QueryInfoFieldInfoBuilder.java
@@ -34,12 +34,19 @@ public class QueryInfoFieldInfoBuilder {
 
 	public QueryInfoFieldInfoBuilder annotation(QueryInfoField annotation) {
 		String fieldName = annotation.name();
+
+		Class<?> entityClass = annotation.entityClass();
+		if (QueryInfoField.class.equals(entityClass)) {
+			entityClass = null;
+		}
+
 		boolean isPredicateable = annotation.isPredicateable();
 		boolean isSelectable = annotation.isSelectable();
 		boolean isOrderable = annotation.isOrderable();
 		QueryInfoJoinType joinType = annotation.joinType();
 
 		return name(fieldName)
+				.entityClass(entityClass)
 				.isOrderable(isOrderable)
 				.isPredicateable(isPredicateable)
 				.isSelectable(isSelectable)
@@ -49,6 +56,7 @@ public class QueryInfoFieldInfoBuilder {
 	public QueryInfoFieldInfo build() {
 		QueryInfoFieldInfo result = new DefaultQueryInfoFieldInfo();
 
+		result.setEntityClass(builderReferenceInstance.getEntityClass());
 		result.setIsOrderable(builderReferenceInstance.getIsOrderable());
 		result.setIsPredicateable(builderReferenceInstance.getIsPredicateable());
 		result.setIsSelectable(builderReferenceInstance.getIsSelectable());
@@ -61,6 +69,11 @@ public class QueryInfoFieldInfoBuilder {
 
 	public static QueryInfoFieldInfoBuilder create() {
 		return new QueryInfoFieldInfoBuilder();
+	}
+
+	public QueryInfoFieldInfoBuilder entityClass(Class<?> entityClass) {
+		builderReferenceInstance.setEntityClass(entityClass);
+		return this;
 	}
 
 	public QueryInfoFieldInfoBuilder isOrderable(Boolean isOrderable) {

--- a/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/join/DefaultQueryInfoJoinInfo.java
+++ b/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/join/DefaultQueryInfoJoinInfo.java
@@ -26,6 +26,7 @@ import com.evanzeimet.queryinfo.jpa.attribute.QueryInfoAttributeType;
 
 public class DefaultQueryInfoJoinInfo implements QueryInfoJoinInfo {
 
+	private Class<?> entityClass;
 	private String jpaAttributeName;
 	private QueryInfoJoinType joinType;
 	private String name;
@@ -37,6 +38,16 @@ public class DefaultQueryInfoJoinInfo implements QueryInfoJoinInfo {
 	@Override
 	public QueryInfoAttributeType getAttributeType() {
 		return QueryInfoAttributeType.JOIN;
+	}
+
+	@Override
+	public Class<?> getEntityClass() {
+		return entityClass;
+	}
+
+	@Override
+	public void setEntityClass(Class<?> entityClass) {
+		this.entityClass = entityClass;
 	}
 
 	@Override

--- a/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/join/QueryInfoJoin.java
+++ b/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/join/QueryInfoJoin.java
@@ -32,6 +32,12 @@ import java.lang.annotation.Target;
 @Target(METHOD)
 public @interface QueryInfoJoin {
 
+	/**
+	 * This is used in specific use-cases when you have a joined entity whose
+	 * class cannot be easily determined at run-time.
+	 */
+	public Class<?> entityClass() default QueryInfoJoin.class;
+
 	public QueryInfoJoinType joinType() default QueryInfoJoinType.UNSPECIFIED;
 
 	public String name() default "";

--- a/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/join/QueryInfoJoinInfoBuilder.java
+++ b/jpa/src/main/java/com/evanzeimet/queryinfo/jpa/join/QueryInfoJoinInfoBuilder.java
@@ -33,6 +33,7 @@ public class QueryInfoJoinInfoBuilder {
 	public QueryInfoJoinInfo build() {
 		QueryInfoJoinInfo result = new DefaultQueryInfoJoinInfo();
 
+		result.setEntityClass(builderReferenceInstance.getEntityClass());
 		result.setJpaAttributeName(builderReferenceInstance.getJpaAttributeName());
 		result.setJoinType(builderReferenceInstance.getJoinType());
 		result.setName(builderReferenceInstance.getName());
@@ -41,14 +42,27 @@ public class QueryInfoJoinInfoBuilder {
 	}
 
 	public QueryInfoJoinInfoBuilder annotation(QueryInfoJoin annotation) {
-		QueryInfoJoinType joinType = annotation.joinType();
 		String name = annotation.name();
+
+		Class<?> entityClass = annotation.entityClass();
+		if (QueryInfoJoin.class.equals(entityClass)) {
+			entityClass = null;
+		}
+
+		QueryInfoJoinType joinType = annotation.joinType();
+
 		return joinType(joinType)
+				.entityClass(entityClass)
 				.name(name);
 	}
 
 	public static QueryInfoJoinInfoBuilder create() {
 		return new QueryInfoJoinInfoBuilder();
+	}
+
+	public QueryInfoJoinInfoBuilder entityClass(Class<?> entityClass) {
+		builderReferenceInstance.setEntityClass(entityClass);
+		return this;
 	}
 
 	public QueryInfoJoinInfoBuilder jpaAttributeName(String jpaAttributeName) {

--- a/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/field/QueryInfoFieldInfoBuilderTest.java
+++ b/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/field/QueryInfoFieldInfoBuilderTest.java
@@ -1,0 +1,145 @@
+package com.evanzeimet.queryinfo.jpa.field;
+
+/*
+ * #%L
+ * queryinfo-jpa
+ * $Id:$
+ * $HeadURL:$
+ * %%
+ * Copyright (C) 2015 - 2017 Evan Zeimet
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.lang.annotation.Annotation;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.evanzeimet.queryinfo.jpa.join.QueryInfoJoinType;
+
+public class QueryInfoFieldInfoBuilderTest {
+
+	private QueryInfoFieldInfoBuilder builder;
+
+	@Before
+	public void setUp() {
+		builder = QueryInfoFieldInfoBuilder.create();
+	}
+
+	@Test
+	public void annotation_defaultEntityClass() {
+		QueryInfoField givenAnnotation = new QueryInfoField() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return null;
+			}
+
+			@Override
+			public String name() {
+				return null;
+			}
+
+			@Override
+			public QueryInfoJoinType joinType() {
+				return null;
+			}
+
+			@Override
+			public boolean isSelectable() {
+				return false;
+			}
+
+			@Override
+			public boolean isPredicateable() {
+				return false;
+			}
+
+			@Override
+			public boolean isOrderable() {
+				return false;
+			}
+
+			@Override
+			public Class<?> entityClass() {
+				return QueryInfoField.class;
+			}
+		};
+
+		QueryInfoFieldInfo actual = builder.annotation(givenAnnotation)
+				.build();
+
+		Class<?> actualEntityClass = actual.getEntityClass();
+
+		assertNull(actualEntityClass);
+	}
+
+	@Test
+	public void annotation_explicitEntityClass() {
+		QueryInfoField givenAnnotation = new QueryInfoField() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return null;
+			}
+
+			@Override
+			public String name() {
+				return null;
+			}
+
+			@Override
+			public QueryInfoJoinType joinType() {
+				return null;
+			}
+
+			@Override
+			public boolean isSelectable() {
+				return false;
+			}
+
+			@Override
+			public boolean isPredicateable() {
+				return false;
+			}
+
+			@Override
+			public boolean isOrderable() {
+				return false;
+			}
+
+			@Override
+			public Class<?> entityClass() {
+				return TestEntity.class;
+			}
+		};
+
+		QueryInfoFieldInfo actual = builder.annotation(givenAnnotation)
+				.build();
+
+		Class<?> actualEntityClass = actual.getEntityClass();
+		Class<?> expectedEntityClass = TestEntity.class;
+
+		assertEquals(expectedEntityClass, actualEntityClass);
+	}
+
+	private static class TestEntity {
+
+	}
+
+}

--- a/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/join/QueryInfoJoinInfoBuilderTest.java
+++ b/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/join/QueryInfoJoinInfoBuilderTest.java
@@ -1,0 +1,113 @@
+package com.evanzeimet.queryinfo.jpa.join;
+
+/*
+ * #%L
+ * queryinfo-jpa
+ * $Id:$
+ * $HeadURL:$
+ * %%
+ * Copyright (C) 2015 - 2017 Evan Zeimet
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.lang.annotation.Annotation;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueryInfoJoinInfoBuilderTest {
+
+	private QueryInfoJoinInfoBuilder builder;
+
+	@Before
+	public void setUp() {
+		builder = QueryInfoJoinInfoBuilder.create();
+	}
+
+	@Test
+	public void annotation_defaultEntityClass() {
+		QueryInfoJoin givenAnnotation = new QueryInfoJoin() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return null;
+			}
+
+			@Override
+			public String name() {
+				return null;
+			}
+
+			@Override
+			public QueryInfoJoinType joinType() {
+				return null;
+			}
+
+			@Override
+			public Class<?> entityClass() {
+				return QueryInfoJoin.class;
+			}
+		};
+
+		QueryInfoJoinInfo actual = builder.annotation(givenAnnotation)
+				.build();
+
+		Class<?> actualEntityClass = actual.getEntityClass();
+
+		assertNull(actualEntityClass);
+	}
+
+	@Test
+	public void annotation_explicitEntityClass() {
+		QueryInfoJoin givenAnnotation = new QueryInfoJoin() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return null;
+			}
+
+			@Override
+			public String name() {
+				return null;
+			}
+
+			@Override
+			public QueryInfoJoinType joinType() {
+				return null;
+			}
+
+			@Override
+			public Class<?> entityClass() {
+				return TestEntity.class;
+			}
+		};
+
+		QueryInfoJoinInfo actual = builder.annotation(givenAnnotation)
+				.build();
+
+		Class<?> actualEntityClass = actual.getEntityClass();
+		Class<?> expectedEntityClass = TestEntity.class;
+
+		assertEquals(expectedEntityClass, actualEntityClass);
+	}
+
+	private static class TestEntity {
+
+	}
+
+}

--- a/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/path/DefaultQueryInfoPathFactoryTest.java
+++ b/jpa/src/test/java/com/evanzeimet/queryinfo/jpa/path/DefaultQueryInfoPathFactoryTest.java
@@ -33,8 +33,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import javax.persistence.criteria.From;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.Path;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -45,8 +43,6 @@ import com.evanzeimet.queryinfo.jpa.attribute.QueryInfoAttributePurpose;
 import com.evanzeimet.queryinfo.jpa.entity.QueryInfoEntityContextRegistry;
 import com.evanzeimet.queryinfo.jpa.field.DefaultQueryInfoFieldInfo;
 import com.evanzeimet.queryinfo.jpa.field.QueryInfoFieldInfo;
-import com.evanzeimet.queryinfo.jpa.join.DefaultQueryInfoJoinInfo;
-import com.evanzeimet.queryinfo.jpa.join.QueryInfoJoinInfo;
 import com.evanzeimet.queryinfo.jpa.join.QueryInfoJoinType;
 import com.evanzeimet.queryinfo.jpa.jpacontext.QueryInfoJPAContext;
 
@@ -71,152 +67,6 @@ public class DefaultQueryInfoPathFactoryTest {
 		queryInfoAttributeContext = mock(QueryInfoAttributeContext.class);
 		doReturn(queryInfoAttributeContext).when(pathFactory).getAttributeContext(entityContextRegistry,
 				from);
-	}
-
-	@Test
-	public void getSubqueryRootPath_isAField_invalidPurpose() {
-		String givenAttributePath = "myAttributePath";
-		QueryInfoAttributePurpose givenPurpose = QueryInfoAttributePurpose.SUBQUERY_ROOT;
-
-		QueryInfoFieldInfo givenFieldInfo = new DefaultQueryInfoFieldInfo();
-		givenFieldInfo.setIsPredicateable(false);
-		givenFieldInfo.setName(givenAttributePath);
-
-		doReturn(givenFieldInfo).when(queryInfoAttributeContext).getField(givenAttributePath);
-
-		QueryInfoException actualException = null;
-
-		try {
-			pathFactory.getSubqueryRootPath(entityContextRegistry,
-					jpaContext,
-					from,
-					givenAttributePath,
-					givenPurpose);
-		} catch (QueryInfoException e) {
-			actualException = e;
-		}
-
-		assertNotNull(actualException);
-
-		String actualExceptionMessage = actualException.getMessage();
-		String expectedExceptionMessage = "Field name [myAttributePath] is not valid for [SUBQUERY_ROOT]";
-
-		assertEquals(expectedExceptionMessage, actualExceptionMessage);
-	}
-
-	@Test
-	public void getSubqueryRootPath_isAField_validPurpose() throws QueryInfoException {
-		String givenAttributePath = "myAttributePath";
-		String givenJpaAttributeName = givenAttributePath;
-
-		QueryInfoAttributePurpose givenPurpose = QueryInfoAttributePurpose.SUBQUERY_ROOT;
-
-		QueryInfoFieldInfo givenFieldInfo = new DefaultQueryInfoFieldInfo();
-		givenFieldInfo.setIsPredicateable(true);
-		givenFieldInfo.setJpaAttributeName(givenJpaAttributeName);
-		givenFieldInfo.setName(givenAttributePath);
-
-		doReturn(givenFieldInfo).when(queryInfoAttributeContext).getField(givenAttributePath);
-
-		@SuppressWarnings("unchecked")
-		Path<Object> givenPath = mock(Path.class);
-		doReturn(givenPath).when(from).get(givenJpaAttributeName);
-
-		Path<Object> actual = pathFactory.getSubqueryRootPath(entityContextRegistry,
-					jpaContext,
-					from,
-					givenAttributePath,
-					givenPurpose);
-
-		Path<Object> expected = givenPath;
-
-		assertEquals(expected, actual);
-	}
-
-	@Test
-	public void getSubqueryRootPath_isAFieldAndAJoin() throws QueryInfoException {
-		String givenAttributePath = "myAttributePath";
-		String givenFieldJpaAttributeName = "myFieldJpaAttributePath";
-		String givenJoinJpaAttributeName = "myJoinJpaAttributePath";
-
-		QueryInfoAttributePurpose givenPurpose = QueryInfoAttributePurpose.SUBQUERY_ROOT;
-
-		QueryInfoFieldInfo givenFieldInfo = new DefaultQueryInfoFieldInfo();
-		givenFieldInfo.setIsPredicateable(true);
-		givenFieldInfo.setJpaAttributeName(givenFieldJpaAttributeName);
-		givenFieldInfo.setName(givenAttributePath);
-
-		doReturn(givenFieldInfo).when(queryInfoAttributeContext).getField(givenAttributePath);
-
-		@SuppressWarnings("unchecked")
-		Path<Object> givenFieldPath = mock(Path.class);
-		doReturn(givenFieldPath).when(from).get(givenFieldJpaAttributeName);
-
-		QueryInfoJoinInfo givenJoinInfo = new DefaultQueryInfoJoinInfo();
-		givenJoinInfo.setJpaAttributeName(givenJoinJpaAttributeName);
-		givenJoinInfo.setName(givenAttributePath);
-
-		doReturn(givenJoinInfo).when(queryInfoAttributeContext).getJoin(givenAttributePath);
-
-		@SuppressWarnings("unchecked")
-		Join<Object, Object> givenJoinPath = mock(Join.class);
-		doReturn(givenJoinPath).when(jpaContext).getJoin(from, givenJoinInfo);
-
-		Path<Object> actual = pathFactory.getSubqueryRootPath(entityContextRegistry,
-				jpaContext,
-				from,
-				givenAttributePath,
-				givenPurpose);
-
-		Path<Object> expected = givenFieldPath;
-
-		assertEquals(expected, actual);
-	}
-
-	@Test
-	public void getSubqueryRootPath_isAJoin() throws QueryInfoException {
-		String givenAttributePath = "myAttributePath";
-		String givenJpaAttributeName = givenAttributePath;
-
-		QueryInfoAttributePurpose givenPurpose = QueryInfoAttributePurpose.SUBQUERY_ROOT;
-
-		QueryInfoJoinInfo givenJoinInfo = new DefaultQueryInfoJoinInfo();
-		givenJoinInfo.setJpaAttributeName(givenJpaAttributeName);
-		givenJoinInfo.setName(givenAttributePath);
-
-		doReturn(null).when(queryInfoAttributeContext).getField(givenAttributePath);
-		doReturn(givenJoinInfo).when(queryInfoAttributeContext).getJoin(givenAttributePath);
-
-		@SuppressWarnings("unchecked")
-		Join<Object, Object> givenPath = mock(Join.class);
-		doReturn(givenPath).when(jpaContext).getJoin(from, givenJoinInfo);
-
-		Path<Object> actual = pathFactory.getSubqueryRootPath(entityContextRegistry,
-				jpaContext,
-				from,
-				givenAttributePath,
-				givenPurpose);
-
-		Path<Object> expected = givenPath;
-
-		assertEquals(expected, actual);
-	}
-
-	@Test
-	public void getSubqueryRootPath_notAField_notAJoin() throws QueryInfoException {
-		String givenAttributePath = "myAttributePath";
-		QueryInfoAttributePurpose givenPurpose = QueryInfoAttributePurpose.SUBQUERY_ROOT;
-
-		doReturn(null).when(queryInfoAttributeContext).getField(givenAttributePath);
-		doReturn(null).when(queryInfoAttributeContext).getJoin(givenAttributePath);
-
-		Path<Object> actual = pathFactory.getSubqueryRootPath(entityContextRegistry,
-					jpaContext,
-					from,
-					givenAttributePath,
-					givenPurpose);
-
-		assertNull(actual);
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,8 @@
 		<version.org.codehaus.mojo.license-maven-plugin>1.8</version.org.codehaus.mojo.license-maven-plugin>
 		<version.org.liquibase.liquibase-maven-plugin>3.4.2</version.org.liquibase.liquibase-maven-plugin>
 		<version.org.hamcrest.hamcrest-all>1.3</version.org.hamcrest.hamcrest-all>
-		<version.org.hibernate.hibernate-jpamodelgen>4.3.11.Final</version.org.hibernate.hibernate-jpamodelgen>
+		<version.org.hibernate>4.3.11.Final</version.org.hibernate>
+		<version.org.hibernate.hibernate-jpamodelgen>${version.org.hibernate}</version.org.hibernate.hibernate-jpamodelgen>
 		<version.org.mockito.mockito-all>1.9.5</version.org.mockito.mockito-all>
 		<version.org.slf4j.slf4j-api>1.7.21</version.org.slf4j.slf4j-api>
 		<version.org.wildfly.wildfly-parent>9.0.1.Final</version.org.wildfly.wildfly-parent>
@@ -277,6 +278,34 @@
 					<version>${version.org.apache.maven.plugins.maven-war-plugin}</version>
 				</plugin>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>${version.org.apache.maven.plugins.maven-source-plugin}</version>
+					<executions>
+						<execution>
+							<id>attach-sources</id>
+							<goals>
+								<goal>jar</goal>
+								<goal>test-jar</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<version>${version.org.apache.maven.plugins.maven-failsafe-plugin}</version>
+					<executions>
+						<execution>
+							<id>integration-test</id>
+							<goals>
+								<goal>integration-test</goal>
+								<goal>verify</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
 					<groupId>org.bsc.maven</groupId>
 					<artifactId>maven-processor-plugin</artifactId>
 					<version>${version.org.bsc.maven.maven-processor-plugin}</version>
@@ -327,34 +356,6 @@
 									<root>src/test/java</root>
 								</roots>
 							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-source-plugin</artifactId>
-					<version>${version.org.apache.maven.plugins.maven-source-plugin}</version>
-					<executions>
-						<execution>
-							<id>attach-sources</id>
-							<goals>
-								<goal>jar</goal>
-								<goal>test-jar</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>${version.org.apache.maven.plugins.maven-failsafe-plugin}</version>
-					<executions>
-						<execution>
-							<id>integration-test</id>
-							<goals>
-								<goal>integration-test</goal>
-								<goal>verify</goal>
-							</goals>
 						</execution>
 					</executions>
 				</plugin>


### PR DESCRIPTION
Added field to QueryInfoAttributeInfo to explicitly set a joined entity
class. JPA/Hibernate doesn't currently have a good way to determine the
joined entity class for NToMany relationshipts. Hibernate pain can be
seen here: https://github.com/hibernate/hibernate-orm/blob/774a16c2d961d7d8b42982ce83de40e3b9b7c37d/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/path/PluralAttributePath.java#L144